### PR TITLE
Updates for 2025 U.S. National Combustion Meeting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ---
-title: Cantera Workshop at International Symposium on Combustion 2022
+title: Cantera Workshop at 14th U.S. National Combustion Meeting 2025
 permalink: /index
 ---
 
 <center><p style="text-align:center;" align="center"><img src="https://www.cantera.org/assets/img/cantera-logo.png" width="300px" alt="Cantera logo"/></p></center>
 
-## Friday 22 July and Saturday 23 July 2022
+## Sunday 16 March 2025
 
 [Cantera](https://www.cantera.org/) is an open-source suite of object-oriented software tools for problems involving kinetics, thermodynamics, and/or transport. Among other things, it can be used to:
 
@@ -18,27 +18,28 @@ permalink: /index
 * Create process simulations using networks of stirred reactors
 * Model non-ideal fluids
 
-This 1.5-day workshop affiliated with the [39th International Symposium on Combustion](http://www.combustionsymposia.org/2022/) will bring together new and advanced users of Cantera, and introduce all to getting involved with Cantera development.
+This day-long workshop affiliated with the [14th U.S. National Combustion Meeting](https://www.combustioninstitute.org/ci-event/14th-united-states-national-combustion-meeting/) will bring together new and advanced users of Cantera, and introduce all to getting involved with Cantera development.
 
-The workshop will begin on Friday afternoon with a session on advanced use of Cantera, and then Saturday morning will introduce basic use of Cantera.
-All workshop attendees are invited to join a code sprint and poster session on Saturday afternoon.
+The workshop will run all day on Sunday 16 March, with a meet-up the evening before for those arriving earlier on Saturday.
+The Sunday morning session will be an introduction and tutorial (bring a laptop to follow along and try things out).
+After lunch we invite lightning talks from attendees (show off what you have tried to do with Cantera, or what you would *like* to do with Cantera), and will have a session on how to contribute to Cantera.
+The afternoon will be a presentation of what's new in Cantera, including demonstrations of the latest features and capabilities.
 See more detail on the [Schedule page](content.md).
-Attendees can choose to attend the basic or advanced sessions, or both.
-You may also register for the poster session on Saturday afternoon without either of the tutorial sessions, if you wish to engage with the Cantera community but do not anticipate using it yourself (eg. lab directors, supervisors).
+
 
 ### Registration
 
 Everyone is welcome, and we especially encourage new users to attend! 
 
-**[Please register here via EventBrite.](https://www.eventbrite.com/e/cantera-workshop-at-the-39th-international-symposium-on-combustion-tickets-278311094977)** by Tuesday, July 12.
+Registration is made through the Combustion Institute when registering for the [14th U.S. National Combustion Meeting](https://www.combustioninstitute.org/ci-event/14th-united-states-national-combustion-meeting/).
+Places are limited to 60 participants, so please register early to avoid disappointment.
+Early Registration Opens  October 9, 2024.
 
-When registering, the "base" ticket gets you into the Saturday afternoon code sprint and poster sessions. Then, you can choose between Friday afternoon or Saturday morning "add on" options, or both.
-
-All participants will have the option of presenting a poster; though this is not required, we encourage everyone to present on the work they are doing that either already uses Cantera or might benefit from using Cantera. This will be a great way to network with other users and generate ideas.
+Participants will be invited to present a lightning talk; though this is not required, we encourage everyone to present on the work they are doing that either already uses Cantera or might benefit from using Cantera. This will be a great way to network with other users and generate ideas.
 
 ### Venue
 
-The workshop will be held in downtown Vancouver, just 1km from the [Combustion Symposium](http://www.combustionsymposia.org/2022/)'s Convention Center, at [Northeastern University — Vancouver](https://g.page/NortheasternVAN?share), 410 West Georgia Street #1400, Vancouver, BC V6B 1Z3, Canada.
+The workshop will be held in downtown Boston, just a [1 mile walk](https://maps.app.goo.gl/j8JTC4QTqYWaPtMJ8) from the Conference Hotel, at [Northeastern University](https://maps.app.goo.gl/tsvobBMr1gMYVfDr8).
 
 ### Code of Conduct
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Cantera Workshop at the 2022 International Symposium on Combustion
+title: Cantera Workshop at the 2025 U.S. National Combustion Meeting
 description: Learn about how to use and develop Cantera
 
 theme: jekyll-theme-slate

--- a/bios.md
+++ b/bios.md
@@ -4,33 +4,23 @@ title: Biographies of Presenters
 
 ## Biographies of Presenters
 
-### Kyle Niemeyer
+### Ray Speth
 
-#### Associate Professor, Mechanical Engineering, Oregon State University
+#### Research Scientist, Massachusetts Institute of Technology
 
-Dr. Niemeyer is Associate Professor in the School of Mechanical, Industrial, and Manufacturing Engineering at Oregon State University. He leads the [Niemeyer Research Group](https://niemeyer-research-group.github.io), which performs research into numerical modeling of reacting and non-reacting fluid systems, and also into using modern, highly parallel computing systems for tackling challenging problems related to energy and the environment.
+Dr. Speth a Research Scientist in the Department of Aeronautics and Astronautics at the Massachusetts Institute of Technology and the Associate Director of the MIT Laboratory for Aviation and the Environment
+He has a particular interest in the development of efficient numerical simulation tools and is the lead developer of the [Cantera](https://cantera.org) software package, which is used for solving problems involving chemical kinetics, thermodynamics, and transport processes.
+
 
 ### Richard West
 
 #### Associate Professor, Chemical Engineering, Northeastern University
 
-Dr. West is Associate Professor and Associate Chair for Graduate Studies in the Department of Chemical Engineering at Northeastern University. He leads the [Computational Modeling in Chemical Engineering (CoMoChEng)](https://web.northeastern.edu/comocheng/) group, which performs research into the development of detailed microkinetic models for complex reacting systems, like combustion, heterogeneous catalysis, and bio-fuel processing. 
+Dr. West is Associate Professor in the Department of Chemical Engineering at Northeastern University. He leads the [Computational Modeling in Chemical Engineering (CoMoChEng)](https://comocheng.sites.northeastern.edu) group, which performs research into the development of detailed microkinetic models for complex reacting systems, like combustion, heterogeneous catalysis, and bio-fuel processing.
 
-### China Hagström {#china-hagstrom}
 
-#### Ph.D. candidate, Aerospace, Aeronautical and Astronautical Engineering, Massachusetts Institute of Technology
+### Kyle Niemeyer
 
-China is a Research Assistant at the [Laboratory for Aviation and the Environment (LAE)](https://lae.mit.edu/) at MIT. She received an Aerospace Engineering B.S. from UCLA in 2020. Before joining LAE, she worked as an undergraduate researcher in the Laser Diagnostics and Gas Dynamics Lab at UCLA studying hybrid rocket combustion using spectroscopic techniques.
-Her research focus is on improving Cantera to help create the first comprehensive analysis of the atmospheric impacts of current and future space launches.
+#### Associate Professor, Mechanical Engineering, Oregon State University
 
-### Gandhali Kogekar
-
-#### Postdoctoral research associate, Brown University
-Gandhali is a postdoctoral research associate in [Goldsmith group](https://www.brown.edu/Departments/Engineering/Labs/Goldsmith/people-page.html) at Brown University. She received her Ph.D. in Mechanical engineering from the Colorado School of Mines (CSM). Prior to joining CSM, she completed her master's degree from Purdue University and was working at Reaction design (ANSYS Inc). Her research is focused on developing robust and computationally efficient models for non-ideal combustion and heterogeneous catalysis in chemical reactors.
-
-### Patrick Meagher
-
-#### Ph.D. candidate, Mechanical Engineering, University of Connecticut
-
-Patrick joined the [Computational Thermal Fluids Laboratory at the University of Connecticut (CTF@UConn)](https://xyzrg.engr.uconn.edu/) in Spring 2019, working as an undergraduate research assistant. He then graduated from UConn as Summa Cum Laude and officially joined CTF@UConn as a graduate student in Fall 2020.
-
+Dr. Niemeyer is Associate Professor in the School of Mechanical, Industrial, and Manufacturing Engineering at Oregon State University. He leads the [Niemeyer Research Group](https://niemeyer-research-group.github.io), which performs research into numerical modeling of reacting and non-reacting fluid systems, and also into using modern, highly parallel computing systems for tackling challenging problems related to energy and the environment.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -10,7 +10,7 @@ The workshop organizers are dedicated to providing a harassment-free experience 
 
 To make clear what is expected, everyone taking part in the workshop and associated discussions—organizers and participants—is required to conform to the following Code of Conduct.
 
-All workshop participants are expected to follow this code throughout the event, and you may also contact the anyone on Code of Conduct subcommittee (Kyle Niemeyer and Richard West) directly by email; see contact information below. All communication will be treated as confidential.
+All workshop participants are expected to follow this code throughout the event, and you may also contact the anyone on Code of Conduct subcommittee (Ray Speth and Richard West) directly by email; see contact information below. All communication will be treated as confidential.
 
 To that end, we ask all attendees to adhere to the following guidance:
 
@@ -48,8 +48,8 @@ If an incident occurs, please use the following contact information:
 
 ### Code of Conduct (CoC) subcommittee:
 
- - Kyle Niemeyer: <kyle.niemeyer@oregonstate.edu>
  - Richard West: <R.West@northeastern.edu>
+ - Ray Speth: <speth@mit.edu>
 
 We expect participants to follow these rules at all workshop venues, workshop-related social events, community gatherings, and online communication channels.
 

--- a/content.md
+++ b/content.md
@@ -4,50 +4,47 @@ title: Schedule and Topics
 
 ## Schedule
 
-The workshop will run 1 PM to 5 PM on Friday 22 July and 9 AM to 4 PM on Saturday 23 July 2022, with a break for lunch. The Friday afternoon session will cover topics for more advanced users. On Saturday, the morning session will introduce Cantera to newer users; after a lunch break, we will hold code sprints, followed by a poster session.
+**This tentative schedule is suject to change.**
 
-Attendees are welcome to come to the morning session, the afternoon session, or both.
+The workshop will run 9 AM to 6 PM on Sunday 16 March, with a meet-up the evening before for those arriving earlier on Saturday.
+The Sunday morning session will be an introduction and tutorial (bring a laptop to follow along and try things out).
+After lunch we invite lightning talks from attendees (show off what you have tried to do with Cantera, or what you would *like* to do with Cantera), and will have a session on how to contribute to Cantera.
+The afternoon will be a presentation of what's new in Cantera, including demonstrations of the latest features and capabilities.
 
-| Start Time (PDT) | End Time | Session      |
+
+| Start Time (EST) | End Time | Session      |
 |------------------|----------|--------------|
-| **Friday**                                 |
-| 13:00 | 14:45    | Advanced sessions       |
-| 14:45 | 15:15    | *Break*                 |
-| 15:15 | 17:00    | Advanced sessions       |
-|------------------|----------|--------------|
-| **Saturday**                               |
-|------------------|----------|--------------|
-| 9:00  | 10:15 | Introduction & Equilibrium |
-| 10:15 | 10:30 | Break                      |
-| 10:30 | 11:05 | Equilibrium Pt. 2          |
-| 11:05 | 11:15 | Break                      |
-| 11:15 | 11:50 | Equilibrium Pt. 3          |
-| 11:50 | 12:00 | Q&A: Equilibrium           |
-| 12:00 | 13:00 | *Lunch*                    |
-| 13:00 | 14:30 | Code sprints               |
-| 14:30 | 16:00 | Poster session             |
+| 9:00  | 12:00 | Introduction & Tutorials (including a break) |
+| 12:00 | 13:30 | *Lunch break (not provided)*           |
+| 13:30 | 14:30 | Lighting Talks (contributions welcome)  |
+| 14:30 | 15:00 | Contributing to Cantera                      |
+| 15:00 | 15:30 | *Break*       |
+| 15:30 | 18:00 | What's new in Cantera (including a break)  |
 
 ## Topics
 
-### Friday Afternoon Sessions
+### Tutorial Session (morning)
 
-There will be two advanced afternoon sessions on Friday, each with three parallel sessions. If you have suggestions for other topics, please include them on the registration form or contact the organizers.
+We expect to cover:
 
-Afternoon Session 1 (1 PM PDT):
+- Installing Cantera
+- Input files (conversion / debugging)
+- Thermo / equilibrium (adiabatic flame temperature)
+- Ignition Delay - ideal shock tube
+- Ignition Delay - rapid compression machine
+- Laminar Flame Speed
+- Sensitivity analysis
+- Flux diagrams
 
-- Using Cantera: ignition delays and flame speeds
-- Build your own reactor models
-- Getting started with contributing to Cantera
+### What's New Session (afternoon)
 
-Afternoon Session 2 (3:15 PM PDT):
+We expect to cover:
 
-- Using Cantera: perfectly stirred and plug flow reactors
-- Build your own electrochemistry model
-- Parallelized reactor simulations
-
-
-### Saturday Morning Session - Getting Started with Cantera (9 AM PDT)
-
-- Introduction
-- Cantera Input Files
-- Equilibrium Calculations (adiabatic flame temperatures)
+- Documentation enhancements: new examples gallery, and expanded documentation for developers
+- Extensible reaction rates.
+- Preconditioners for faster reactor integration
+- Real gas models in 1D simulations
+- Catalytic combustion with the new PFR
+- New mixing rules for collision effifiencies
+- Blowers-Masel for thermodynamic sensitivity
+- Reactor network visualizations

--- a/materials.md
+++ b/materials.md
@@ -2,7 +2,7 @@
 title: Workshop Materials
 ---
 
-The materials that will be covered in the workshop will be available in the form of Jupyter Notebooks on GitHub: <https://github.com/Cantera/symposium-2022-materials>
+The materials that will be covered in the workshop will be available in the form of Jupyter Notebooks on GitHub: (link to be provided).
 
 ## Installing Cantera
 

--- a/participants.md
+++ b/participants.md
@@ -5,13 +5,11 @@ title: Participants
 
 The meeting will be hosted by
 
-* [Kyle Niemeyer](./bios#kyle-niemeyer) (Oregon State)
+* [Ray Speth](./bios#ray-speth) (MIT)
 * [Richard West](./bios#richard-west) (Northeastern)
-* [China Hagström](./bios#china-hagstrom) (MIT)
-* [Gandhali Kogekar](./bios#gandhali-kogekar) (Brown)
-* [Patrick Meagher](./bios#patrick-meagher) (UConn)
+* More to be added...
 
 ## Attending
 
-The workshop will be conducted in-person at [Northeastern University's campus in Vancouver](https://vancouver.northeastern.edu/).
+The workshop will be conducted in-person at [Northeastern University's campus](https://www.northeastern.edu/) a pleasant 1 mile walk from the The Westin Copley Place hotel which is the conference hotel for the U.S. National Combustion Meeting.
 Registration information is on the [homepage](./#registration).


### PR DESCRIPTION
I'm about to suggest they include the URL https://workshops.cantera.org  in the call for papers that's about to be sent out. It'd be good to have at least a placeholder website there. I ended up putting most of the details in (subject to change, of course).  